### PR TITLE
Allow for writing https tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,11 @@ var inject = require('./inject-script-tag')
 
 module.exports = function(resp, opt) {
     opt = opt||{}
+    var protocol = opt.protocol || "http"
     var host = (opt.host || 'localhost').split(':')[0]
     var port = opt.port || 35729
     var injector = inject({
-        src: 'http://'+host+':'+port+'/livereload.js?snipver=1'
+        src: protocol + '://'+host+':'+port+'/livereload.js?snipver=1'
     })
 
     var stream = responsify(through())

--- a/test/https-expected.html
+++ b/test/https-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+</head>
+<body><script type="text/javascript" src="https://localhost:35729/livereload.js?snipver=1"></script>
+    <script>console.log("second")</script>
+</body>
+</html>

--- a/test/https.html
+++ b/test/https.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+</head>
+<body>
+    <script>console.log("second")</script>
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,7 @@ test('inject script into body', run('body'))
 test('inject with opt', run('opt'))
 test('inject without any other tags', run('none'))
 test('inject without any body tag', run('no-body'))
+test('inject with https', run('https'))
 
 function createServer(cb) {
     var handler = ecstatic(__dirname)
@@ -36,6 +37,8 @@ function createServer(cb) {
         var opt = {}
         if (req.url === '/opt.html')
             opt = { port: 3000, host: '12.0.0.0' }
+        if (req.url === '/https.html')
+            opt = { protocol: 'https'}
         return handler(req, inject(res, opt))
     }).listen(8000, cb)
 }


### PR DESCRIPTION
I'm adding SSL support to Budo and need to allow injecting of livereload.js over https so there's no mixed content errors requesting it over http.
